### PR TITLE
Removed ITSM-CIAttributeCollection.sopm

### DIFF
--- a/ITSM-CIAttributeCollection.sopm
+++ b/ITSM-CIAttributeCollection.sopm
@@ -111,7 +111,6 @@
     
     
     <Filelist>
-        <File Location="ITSM-CIAttributeCollection.sopm" Permission="644"/>
         <File Location="doc/CHANGES_ITSM-CIAttributeCollection.md" Permission="644"/>
         <File Location="doc/en/ITSM-CIAttributeCollection.pdf" Permission="644"/>
         <File Location="doc/en/USAGE_itsm-ciattributecollection.pod" Permission="644"/>


### PR DESCRIPTION
When installing the package you will get "ITSM-CIAttributeCollection 6.0.2 - Package not correctly deployed! Please reinstall the package." because "ITSM-CIAttributeCollection.sopm - File is not installed!"
This file is not necessary when the opm package is build as far as I know. After removing the file from the opm file list and reinstalling it on OTRS 6.0.8 the error was gone.